### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides SMS messaging and Text-to-Speech (TTS) call capabilities through ClickSend's API. This server enables AI models to send SMS messages and initiate voice calls programmatically.
 
+<a href="https://glama.ai/mcp/servers/6nj3h62i6b"><img width="380" height="200" src="https://glama.ai/mcp/servers/6nj3h62i6b/badge" alt="ClickSend Server MCP server" /></a>
+
 ## Features
 
 - **SMS Messaging**: Send SMS messages to any phone number worldwide


### PR DESCRIPTION
This PR adds a badge for the [ClickSend MCP Server](https://glama.ai/mcp/servers/6nj3h62i6b) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/6nj3h62i6b"><img width="380" height="200" src="https://glama.ai/mcp/servers/6nj3h62i6b/badge" alt="ClickSend Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.